### PR TITLE
Laravel 6.0 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
-        "illuminate/support": "^5.8",
-        "illuminate/console": "^5.8"
+        "illuminate/support": "^5.8 | ^6.0",
+        "illuminate/console": "^5.8 | ^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
From what I could tell based on `composer.json`, this package is compatible up to Laravel 5.8. I went through the [respective upgrade guide](https://laravel.com/docs/6.x/upgrade) and did not find any further changes necessary.

Since Laravel, starting from 6.0, follows Semantic Versioning, the new constraint can safely be `^6.0`. Backwards compatibility is not affected.

Let me know if you would like me to make any changes to this PR!

This closes #1 